### PR TITLE
Fix lesson not found with tag H5

### DIFF
--- a/WWW-COURSERA-DOWNLOADER.ipynb
+++ b/WWW-COURSERA-DOWNLOADER.ipynb
@@ -672,11 +672,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "variables": {
-     "len(titles)": "13"
-    }
-   },
+   "metadata": {},
    "source": [
     "###  <b style=\"color:royalblue\">PICK ONE OF THE COURSES</b>\n",
     "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAVEAAACWCAMAAABQMkvIAAABJlBMVEX///8BkNze5+xfjaf/xyz6//8AiNYDPFoAjdsVjMoBkNv//v8AitsAhtJaiqUAjdy94OnN7Ppls99WhqEAg9WIwtzL6u/w9PYYk9a12+1Bodnq/f/m7PCb1u5frtQAMVIAis/a8fit3OuazOH0//////Tr8/VhiqEAM1SGxedwh5KCmaXL2d+fsbX/xBh6nbIAI0mSr7+wxdDA0dlRd4SqwM1slKv999b9++sAAC+DpLeZs8EAIUYAKUz65qT5xTQgTWf77bcAED90ut8mldBTqdt9vN8AD0A3WW+dzN+84OiAlqNFoM6v2/InTmikv8Lf//8AFj6WprJceIkvn9788sv44JD10Gikv8753IBIeJNLaHv30Fn54ZX1x0XS5e7246tGjrb4REX+AAAUOklEQVR4nO2dCVvayv7HY2xChASEqCikFRSCSyqS/Ame4FIP4G2r9na5Vtprl/P+38SdmSSQZSYJgajn/PN9HmULYfjkN79lZhIoKtUj6KT51C34p6h3Yt5+6z1tO/45urxHN72jyyduyD9Gl0df4c29eUNRaecP0OcoG929ODoH/4+OHuCjk2//CFPNJbJXqSvqavhmgOhFj7r89vAArPPy54uTRBrzeMq5bhYqSc8vM+gejf+M33fwf+/htwnxhGreHx19S6AlT6TFQ1XbbQncKG8U/OuXRw/nPeQ4T3o9FPLPX/wz4pMsSUwS+5XQ/8NPX6yHtHcDYJIXAGTv/uII3LsHJnv38Hfv9ABnvyUCtbWE3On18bFpolJnue957eTi6I5qfj06egEFenxzjkifTDCYXaqYX4bKi22ZvFWnG3f/3dNMxuwAZf27r/ef/6Ca30yeiOk9QHp5eX7+45lm++X+eNztakGb9MVlW/m8r1eaylFyXo/ZBHkvs/fFMh/1l+IzpCb1YwoUIP1KNX8CD3Ae8+OSlizm83nRCNhCnQIFSFskb0rnxzGb8Hk7s3dAfBWU8r0XbvWo86OLZxudZMgr3wnZwIGUsCkw5Lwe4BMC9CFDINq8O//2APLQr0cuoCB56v2cocvXd/aBbjcasVo3swAwXQ+y0X7eRXRZLOO2YlqQtkFIgQIlnWVgr8eoeQ7i+0WT+umx0Z8zBKfioCawbIHjWFYY3VZjtG9WNVRN1bRfxNeZZY9EbImjIUvOf5dmb4F2nMlkPqC7tNeMTn5cPDSbHqAvLiIYqOmMVytCYWkijq+tJ22ojIrSIlHsyITMQv4OHS1SQLeXWwZ6WYxhpCqw0cwZjfbS8r16ckk1j/xEfwS7UfO7VEssN+WZhf/YzS34cmJZlKyLogFMtL8sioRwr6hQ43G/Y7R1kD+BDAqzVUdpmwZMSAWCpEGi24fwbhdf4vts9IR6OHq4C9txcaXgYGnbqbBOJZeXlluiYXZTRiUh1cb9fqdjGEanP+4iupo/2hsaY8YvMUZsokE2CpCS3tlrUg9eP2qmT/fBpdOqwJkwLaDZ7BKyWLY0exujqi2aBQo8YoooYn0g02rpbaPTGUN14Z/ht0OVKltEY1SqDASa2fsv/tVLUDGde2L9V+rk/utlLzg6FYUlgtjB7I2MIlkbi8uKTScnj8V2AxfGNbULO7zlb4EwxqRQjFVVeWvIKDrYg0jPsAnUORxoOnEH+yiBiarWOBLRJXY3RivDpXwHGaRohxkaPcK5SLUDoo2iMIxM07SiaV0MdrrM6MDJAqJxKlH6GFnp2RefgYPqE9TzPerSZaLn1En4UMmIDHRpSajHaGaoZKOj93U7Nsvttt72jVJAGcDBMq3vNEWLoMxUOjh3K9OU3oHRnlhRBer6DCHdfqN63n5y1+udmCN4U6A/KOrbfdgud1hXPPKIq8RpZqhUrf1rapSaavzy5y4UdLagT8OQo0ATVkVszaRQxhiWAvFKe+btdsY008zBa017feDx6KCXX15YY0+w+gSuIKQGZYaFIKJLa6uxGhqirqZHIaoDomURhBwNVlZdEduvFUptd/PLcQdLmLemlYIAtX12/C9PUtt88QPWT/c/f/68PwcWe/JgDpkGaIsNwJmYkXYV/de0+iQRZXSQY8qiaJlnH18yKZSid/LLMQt7oOtTy0z3jv/r3cmllSg10fqH3gnV7P34+TVwd6NCINBsMp60C0zKQbS93MFZGNMCHZ4Wl6F5AjfbwaetCnDLRj5WXLIkXb85Oz09y3zx7//b0cV5k7pDUC+/vUCZffMuKHdqEDMnW3wS4b4LoruDKHiEC/Wow/+CQakPO7yBrzOBqzVahJI/smRa8c+85KiTi3uYLj1cXIA8FGT2obUSSO5DOj3o9qO5mooXSEcdYYZEFHV4FJQ6EFgbS1Rrd2GkJ1Wys8lbId79RjcgkQJgexc20aBCcp1bWgqMTEvcZgKzZv1xazwlqraXDRxR1OFRUIJpFKXjKnfasMZRWvMZaaB+m3PKd1EmQktByaipWgIDe/1frV9Tou7IPxXKQlXoQlEalcfVqoY9hJrvYwdPF6K7F2apdP47fNtScGCCSiI0dSIRRR0eBSVonowoYgYY25NB6TijeRHV+2HdiTC1HBLqEyRKO4gqeKKow8OcCWT5khmnfOpPRk/jjOZFVHOGOeXEbZQxVWbKSOYjZKPTsrOrtH7h5ka0FtjG+A6Iit9hGoWrM418u9PWRTGPjW1PoAhEI/lRpizRtKJoqtrt9vtwTBMU63prqjwcQJo8gpFkWdfbhtHp9MftTmvcVhSalssuZvAZRqaBf1QBWrqFy1l1lDYx5Q6+RH187YZmT0tD3PuYhgxHg9QuoKcvi1Pl8+6JjEBNt83nJ3to6Uan31U1RQG4wYFpt63HNG4QVbfSJkOMM5iXgFYDx0mguOmwMzRERQMQp0OWEdHNJrhT0TRpOOI8Ho/RAH637+/15bzlPttzpvgLU6MWZqL8Luh4gOPEFkkQLXMTvZpsrrtwebcJ220ewu0CS5WdXGUxb6AnWwmG+tlUKoTYaHa55eLiNyWzq6L5CzgfpIH+CjwgLUnyNBZ5hKKUhFwvcL7AecDZOQN6XidjkunqbYCWhlWj2rcdRpKhfjaFlqErBIqtqXuTG8yi6ioGjdd7HbSXrtmIVstYnj4vqjHm6xNRhQv2pH9NvoEZNMaqt+clKeRx1DH03FZXcZN1PHguoYlaDR59WjF72VgFGJMr86IIhkV1bE/kYbxQe6zR5cc61AFq3ASV9rWtpwbpVxnYrdo39LwXLHxCB4GKfrIWS4ra0Vv5gHDP3j5V2yKIkRUN+IOW2xlAB9XSO6oSe0w/nmSla6CmgDb8RfSj7PrjtiqeZFqzvswULIpcRvdxsEKYrsOa/8ucsfeBZfcfoz0LEgN6XB8arOOLQa7JYi0rquH8TLuHrFZYvzPlhGSWP+C0sNVVwBNAT+b9joaagG+VtL7u+aCpF2/sC54hE46vzDvmVLYlI0lQ4LYs288zC0tjPSrT2thnOu2+tjBjZWjV0EXRfdRAZ7C/D7SQekngJ3bKFdjhzozfNpdD8CRYCc0oiBq+ebHrAIG5urAiG+po9NxHkTY7usNjEzxLfb0isEjC5qAY9XNzJsaZKZLpytB45/vOjkNjRw23C4i7Y2ibjr3B86z6gW66sfH+5cud1UgTS1ZhnpiQ2S7Iat0eD1mVNnvNKmudlpPmMjg0C3FbTESUpt8sY2V51Uh7kRdTB5VdnRXaamcGv8oofd35ZuA+FnFmJWQZjNCMN7PE7lyOyjHmSFTgvgHX+Q2WobWOC0y7q0TgIsFjkc9PaOJDHHaQjahGo1olfGHTDhcVVGB8I7tlcMTm/gRGcnRe4FdbRrCp0uPJMQA080TDLq7MrJLne0KSCZ49SiS7CKyAqui0ui4+VjFKx2HRIKQFON8IKx98CX9xijK5U0h8XwqAxWJdQBLUdjqAjrf/lzXDej1vQg/8xLoQMnKPQzqQHpWlQ9AX+LnOT9UZbyBUbWL98gQnPOsnxDFA7YdPKvuJrjzSyY0k5TBJxvxUJc3IT6EaJtQJThiHogSvxubMnR6I3XkOZ93nfNYqzevOgam23FDzIQ7Wp53wWXq/sgmtyY8jnxOIPyxuHQ26q097OWWmVmr0fLUSx0SXloRi3GYnIa+xSvOmAJJqO1UKXsVjlmGVjdCFzXgVEjphLL4YN1Vp3hlFyYz/1AzWiRRhsRPBSB/jHPFZ5aEaH6rZ/2UAddZ3VmOa6DOeJVkUVFPSrEPgEVaPkbTyDCZvCXKbapLVnP+jh95T6Wcw0q1HbOjMcsWquXOq6HKvyyEizeJeSeTEkUXKDfWRepTrzFouLI/i3GCTOfN2sXJCfQxDrTvjEjcYCZhpUFsFdrjvAfz3mHB2QJ07TQ3VujN1YutU9baEh8qxNTjd5E4Mnry4j6pc+bGYVlec9Fh0aaDGTqnGI9Do0hrwX4GvjczZUE+qZcamZ1Dfh8thqHJSDWYkyZ06sfbFlhqrg83JlD3HC5V3djLvJpotuGNTY2cwqpR2n6t3dRhqElGKAcdMcl/xgXVcvqpRvBrC7s8B5+kg5CQKrdcVm7Y2eQ6IFQbP1RlMDXXhnd/ctecqL6z7gmBMfX9YG2y4Dqe3wCo46qZ11l4wxVeeK1KHR10oU+tQSVd8EFEKnlbjecJXsk7rJtuDQNPlXy2wtYvWgpnmzP6OVN900+HrjWIxePjDR5TdsV7ZEpwFAvscfekkIE07/yKY5uy9STnfeQyVmiAIo42Ad/uI2nXThgvoEvd4K/liacJ07hiVc+7JNwWKHgeua/QPVJljevUa56xUs88v91cOX7vgMYthWp7YJwUvluVmYwPhBPLqcD/RAuRf9U5Vse/maaatRvF2a0HuQ/u0fey5fNuUaey9lt1HZZf34bFUI4ZqzGDqEHxz38TKQir+3RWe54XRQga2v+xlMp+8E28TpvHcac779grxBDvy5dwwRIUNNNzi2hd75X9rt0M7qis6/ILgr3iuwBe4ghDk2KMKEv3TP7thM43T9WXv4QiYX+KIU0j+92QLg4E3whVu3A1EZ9Gja2FMBK/oQFrVbHJf55eEwdbuJlfYjJLd1rcmO8MVmfT29uk17n3lmF3ffp/jKF2R55cKxIFPH9EsDEPeAzL0ILgaVobvDHH1pmJrSIvGu+FwSO7RwMsLlouOcAXE+kDgh1sBhsYoh77TmaUPyLzKMbq+3eElx9FjNsknLM5iow60tja9nEo8x7/8rK/WChxKKDhOoPXXuzznd7eNqqUdntv8CG4b+1yhYj9ZxTOrl9AoBFshMz043X7rfe7LFw8e0pt9wh6EoJNqZ/KjvsNR8/m9UgHkrS9f7mcn4Ln9/X3gff1EKzVbYCt0C980eRLnUi2eS2gQYgezAdSe/yriyh8ThMxsZir5Ojz6lgHj9TPFeq+lYlZGlLgs+Lase7oAThhgiAY0CxukAE/XiCS+7ytnmczbAyTadrQfDh0blKObKePv8FBBFycIOFsx3EYFjJUQlwTgiG4SJ7v+s+QjOrVPB1PMiS3o6rd7UNsZ6yn1k3szaWqmgeOnZYI5B1zFMWgePpQo1mGUOIIwRPmXeKTZJX5n00PUY59Tpl47RVdo3t7ePtvePn4rv0bae41HFbKAxALvP2jklSR80MKGMKK4RBRGplEJp//giZIatlNzEa2/8tnnkumoC16msNNv9/v9fwM1lP9D8l+t2YpQQT2fIVL3VqCOdgdW5CFECdcjL63hS6hXMxJ12qi7v8OB7kJharCeGHUNrykKGA9h4ja0M7ihN8sj9ugIr+NWOKJIHLL0JpgoN8JnLxOiysGBRh1cH5p3ZibqtNF6hTcbDUe4a6N9kEqUVlj7Er9ZTnCMLKBOD5KnxhoPVeBAMQaV9aXDTCBSOcCGCddzywZ2eSqEKEdK2CdEu59O+9TpWYZRPx1/no8oxaxbjWE3333c2L0a7O98LNq/NsG6zmNVjs2fYGHWkUZcoWTew+Q05J5vOQU8bVKnD10cFkjUl9nbmhBV90A8yGTewDvzEgV19AoPe9XVx90VFpgdxwqljVU4CsYJ+67Ocr2Hft3CLnp3WT5gfVEZmxsBBZovIdKHr7YLIlojjjctyo96iFKNEguytY3hJNMtCOsfK1xhxZMSv0EXZjb/f4aDbkFEqRw2mlv+gJRYDbCdvhA+TBxAdJLZ+z8UEb0+/Ewph4cKdWjemdOPmroVdlYFZwXMjz6ueMf/lNPMRPCHWEKI2j3fZY1McBrA4M9lCJgcsimRibKk+o8yiTJ/nH2gXkM/+uksA9Lr0/l7PVS1aKekFtbCjc/3HByDPBTJIhrY66F8SMsheRXht0P8c6E+4d+YzQb/Qgay0VMQbbtn26+pbehHz7YXQ5R6VZi0wdSarwpWX9t6E5GoRbBMeOjXLj4zjjCBSbJRfGZvCxFFo6Hmn3VnoURtcayPKHM1GFyBv1LxbVSiboahQH2tsIhyo63AGQimeEUYx2CD5+cRUU3TKEnT6OmdRREt8IJQ29zcrAksSPL9RBuvYHkGarStD5GJOiky9l1yvU9qM8fWKsRVSxv7MIHGv+8meFIBEf3j+A3V/fPTZ+rT8R6jwjsLIJqjBrzw6rZYbUB9LO5WBD9RqH20VCNyr6ecSMMH+qoB54GCpG64XvRlvvV1kKKQBtoKvmrOIzMyQaL/+tMiCu/MSLSAtdGbgfto1mvY3z7ZRwszZyE6RRoGNOc/PcSzdLkgbA62HJCq4MgT503B5iths5XIRkGzYCPl6Z2F9Pr1FecvRTL1AT4tjkHUQspQoUCpOusmyA58NsuBUvkWNa16ixY++7eY3CFn9raSGCmZaOumdjPYvYVaL63UrvCHNw5RCykVPrbvIcruY4vSAnSqWwAnznlyA+syWxw/DM8QSvzVOk4VP9Hh2ku4VAintZ3aGnaiubq1XhqNbkalwTu/v7I0IXo9A1ETKRU+su/+QRaQ+HiI2j8ZCK/0ZP0uRtYzIc/vUjAIAKe7G2Gmu7SGF+8nWi9WiySBV2KvooxHFCGlIkyVjBw/XwkzSfJoKUlojKpRr0f7hhurHr237zzaOWb7aO7s7d5ZlCrUIVA9RVkVb9dMcGgRpuYxif6dtHsDiWqZtyAgvssK0c9tk6KdU79ujz2tocGRpIk+/akPrhYwDcK8P1YRr1LwsgZXFPG1l+hRdebrlPztbDS+oi41qe6+Gr3atTKNqnWJvOha+/9DNJYYGCzev/f9WyX9e//+Oa4KT5UqVapUqVKlSpUqVapUqVKlSpUqVapUqVKlSpUqVapUqVKlSpUqVapUqVKlSpUqVapUqVKlSpUq1SPrf1Xbo1kAh/l9AAAAAElFTkSuQmCC\">\n",
@@ -702,12 +698,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "variables": {
-     " titles[chosen_course-1] ": "Neural Networks for Machine Learning",
-     "-titles[chosen_course-1]-": "<p><strong>SyntaxError</strong>: invalid syntax (<ipython-input-16-f2678fc1f121>, line 1)</p>\n"
-    }
-   },
+   "metadata": {},
    "source": [
     " ### {{ titles[chosen_course-1] }}"
    ]
@@ -810,7 +801,7 @@
     "    seq = 0\n",
     "    for i, module_lesson in enumerate(module_lessons):\n",
     "\n",
-    "        lessons_title = module_lesson.find_by_tag('h5')\n",
+    "        lessons_title = module_lesson.find_by_css('div.rc-WeekItemName.headline-1-text')\n",
     "\n",
     "        for j, l in enumerate(lessons_title):\n",
     "            seq  += 1\n",
@@ -1164,7 +1155,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I think coursera has minor adjustment on course page. The lesson title can not be found by

```
lessons_title = module_lesson.find_by_tag('h5')
```

I replace title search by css 'rc-WeekItemName.headline-1-text'. 